### PR TITLE
add docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+DATABASE_URL="postgresql://admin:1234@db:5432/ohmydog?schema=public"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Usa una imagen base de Node.js
+FROM node:14
+RUN apt update
+RUN  apt install postgresql-client -y
+
+# Establece el directorio de trabajo en el contenedor
+WORKDIR /usr/src/app
+
+# Copia los archivos del proyecto al directorio de trabajo
+COPY package*.json ./
+
+# Instala las dependencias
+RUN npm install
+
+# Copia el resto de los archivos de la aplicación
+COPY . .
+RUN cp .env.example .env
+
+RUN chmod +x /usr/src/app/entrypoint.sh
+# Expone el puerto en el que la aplicación se ejecutará
+EXPOSE 3000
+
+# Comando para ejecutar la aplicación
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,15 +7,43 @@ Está construida bajo la arquitectura MVC.
 ## Requisitos técnicos:
 * Node.js 20.11.1
 * npm 10.2.4
-* PostgreSQL
-* Definir archivo ".env" con las variables "DATABASE_URL" y "PORT"
-* Envío de emails: Definir en archivo ".env": "USER", "PASSWORD", "ID_CLIENTE", "SECRET_CLIENTE", "REFRESH_TOKEN" hecho con Google OAuth2.
+* Postgresql
+* Docker y docker-compose como deseable [Instalación aquí](https://docs.docker.com/compose/install/)
 
-## Instalación:
-* git clone https://github.com/alanberns/ohmydog.git
-* cd ohmydog
-* npm install
-* npm start
+## Instalación local:
+### Sin Docker-Compose
+* ```git clone https://github.com/alanberns/ohmydog.git```
+* ```cd ohmydog```
+* ```cp .env.example .env```
+* ```npm install```
+* Levantar una db Postgresql o con ```docker run --name ohmydog-postgres -e POSTGRES_PASSWORD=1234 -p 5432:5432 -d postgres```
+* ```npx prisma migrate dev --name init```
+* ```node pruebas/resetdb.js```
+* ```npm start```
+  
+La app levanta en el puerto 3000.
 
-* npm resetdb - datos de prueba: pruebas/resetdb.js
+Postgres
+ - db: postgres
+ - user: postgres
+ - pass: 1234
+
+### Con Docker-Compose
+dentro del direcotorio raiz: ```docker-compose up -d```
+
+Para eliminar todos los contenedoras: ```docker-compose down```
+
+La app levanta el puerto 3000.
+
+Postress 
+- db: ohmydog
+- user: admin
+- pass: 1234
+
+
+### ADMIN DEL SISTEMA:
+user: ohmydogis2@gmail.com
+
+pass: 12345
+
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: ohmydog
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: 1234
+    ports:
+      - "5432:5432"
+    networks:
+      - ohmydog
+
+  node_app:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    networks:
+      - ohmydog
+    environment:
+      PORT: 3000
+      DATABASE_URL: "postgresql://admin:1234@db:5432/ohmydog?schema=public"
+
+networks:
+  ohmydog:
+    driver: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Hola desde el script Bash"
+npx prisma generate
+
+IP_DEL_CONTENEDOR_DB=$(ping -c 1 db | awk 'FNR == 2 {print $5}' | tr -d '():')
+export DATABASE_URL="postgresql://admin:1234@$IP_DEL_CONTENEDOR_DB:5432/ohmydog?schema=public"
+
+npx prisma migrate dev --name init
+node pruebas/resetdb.js
+node app.js


### PR DESCRIPTION
Pequeños aportes
Define un archivo dockerfile y un docker-copose.
Extiende la documentación en el Readme con un paso a paso para levantar la app con y sin docker-compose.

Cabe aclarar que si bien las variables de ambiente deberían definirse solo en el .env, Prisma ORM tiene algún problema que no permite que interprete bien el DNS de docker-compose, por esto se implemento el entrypoint.sh para que interprete la ip del contenedor con la base de datos y la redefina en la variable de ambiente DATABASE_URL.